### PR TITLE
Automatic and Repeating Reconnection to Server

### DIFF
--- a/Drivers/NUT UPS Driver.groovy
+++ b/Drivers/NUT UPS Driver.groovy
@@ -1,6 +1,6 @@
 /**
  *  NUT UPS Device Type for Hubitat
- *  PÈter Guly·s (@guyeeba)
+ *  P√©ter Guly√°s (@guyeeba)
  *
  *  Usage:
  *  1. Add this code and "NUT Child UPS" as a device driver in the Hubitat Drivers Code section
@@ -177,7 +177,17 @@ def connectToServer() {
 	if (nutServerHost != null && nutServerPort != null) {
 		log.info "Opening telnet connection"
 		setState(STATE_CONNECTING)
-		telnetConnect([termChars:[10]], nutServerHost, nutServerPort.toInteger(), null, null)
+		connected = false
+		while(connected == false){
+		    try {
+			connected = true
+			telnetConnect([termChars:[10]], nutServerHost, nutServerPort.toInteger(), null, null)
+		    } catch(Exception ex) {
+			connected = false
+			log.error(ex)
+			pauseExecution(nutReconnectDelay*1000)
+		    }
+		}
 		pauseExecution(1000)
 		if (isAuthRequired()) {
 			nutAuthPhase1()


### PR DESCRIPTION
I added a connection-status controlled while-loop in place of the singular connection request. If there is an error/exception thrown such as timeout or no hostname, or anything else, it posts that to the log (maybe change that for debug on only) and then waits as long as the user input on the preferences page, then tries again. It does this until it does not get an exception, therefore it breaks out of the while loop.